### PR TITLE
Add CC Usage tool to Additional Tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ The list is organized into categories, and each entry should be placed in the ap
 - Slash-Commands
 - `CLAUDE.md` files
 - Workflows
+- Additional Resources
 - Official (Anthropic) Documentation
 
 Within each category, entries are listed in alphabetical order. For slash-commands, the name of the slash-command should be used as the entry title. For `CLAUDE.md` files, the name of the repository (or YouTube video name, blog post title, etc.) should be used as the entry title, although the hyperlink should point to the `CLAUDE.md` file itself (or the media that describes or contains it).
@@ -20,6 +21,8 @@ Within each category, entries are listed in alphabetical order. For slash-comman
 Each submission should contain only a single entry. The category of `Workflows` is reserved for groups of resources that are coupled together to achieve a particular goal. For exanple, a `.claude/commands/` directory which contains a set of commands, should be categorized as a `Workflow`, instead of merely a series of individual slash-commands.
 
 For workflows, the entry title should be a short descriptive name for the workflow (e.g. "Documentation Maintainer" or "Project Management Workflow"). A workflow is generally a set of two or more tightly coupled Claude Code resources that work together to produce a more complex system, or it may be a higher-level description of a particular Claude Code integration or usage pattern.
+
+"Additional Resources" is for other applications or tools that are layered on top of Claude Code, or somehow enhance Claude Code, but do not consist merely in Claude Code "native documents" like `CLAUDE.md` files, slash-commands, and the other parts of the official Anthropic Claude Control "control flow."
 
 # Prohibitions
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Claude Code is a cutting-edge CLI-based coding assistant and agent that you can 
 - [Slash-Commands](#slash-commands)
 - [CLAUDE.md Files](#claudemd-files)
 - [Workflows](#workflows)
+- [Additional Tooling](#additional-tooling)
 - [Official Documentation](#official-documentation)
 
 ## Slash-Commands
@@ -210,6 +211,10 @@ Claude Code is a cutting-edge CLI-based coding assistant and agent that you can 
 - [Project Workflow System](https://github.com/harperreed/dotfiles/tree/master/.claude/commands) - A set of commands that provide a comprehensive workflow system for managing projects, including task management, code review, and deployment processes.
 
 - [Simone](https://github.com/Helmi/claude-simone) - A broader project management workflow for Claude Code that encompasses not just a set of commands, but a system of documents, guidelines, and processes to facilitate project planning and execution.
+
+## Additional Tooling
+
+- [CC Usage](https://github.com/ryoppippi/ccusage) - handy CLI tool for managing and analyzing Claude Code usage, based on analyzing local Claude Code logs. Presents a nice dashboard regarding cost information, token consumption, etc. [DISCLAIMER: Keep an eye on the Issues if you are relying on this tool for anything business-critical - the logs that track usage appear to suffer from some "double-counting" problems - this may have been resolved by the time you are reading this, but I wanted to raise awareness - it is not something only affecting this application.]
 
 ## Official Documentation
 


### PR DESCRIPTION
## Summary
- Add CC Usage CLI tool to Additional Tooling section

## Description
CC Usage is a handy CLI tool for managing and analyzing Claude Code usage based on local logs. It provides a dashboard with cost information, token consumption, and other usage metrics. Added with appropriate disclaimer about potential double-counting issues in logs.

🤖 Generated with [Claude Code](https://claude.ai/code)