### PR TITLE
Add CCProxy to Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ A pretty stunning list (88 at the time of this post!) of slash-commands ranging 
 [`CC Usage`](https://github.com/ryoppippi/ccusage) &nbsp; by &nbsp; [ryoppippi](https://github.com/ryoppippi)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
 Handy CLI tool for managing and analyzing Claude Code usage, based on analyzing local Claude Code logs. Presents a nice dashboard regarding cost information, token consumption, etc.
 
+[`CCProxy`](https://github.com/orchestre-dev/ccproxy) &nbsp; by &nbsp; [praneybehl](https://github.com/praneybehl)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
+Use any AI model with Claude Code - OpenAI, Gemini, Groq, OpenRouter and local models via Ollama. Universal API translation proxy with intelligent routing and streaming support.
+
 [`ccexp`](https://github.com/nyatinte/ccexp) &nbsp; by &nbsp; [nyatinte](https://github.com/nyatinte)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
 Interactive CLI tool for discovering and managing Claude Code configuration files and slash commands with a beautiful terminal UI.
 


### PR DESCRIPTION
## Description

This PR adds CCProxy to the Tooling section of the awesome-claude-code list.

## What is CCProxy?

CCProxy is a universal API translation proxy that enables Claude Code to work with any AI model - from cloud providers like OpenAI, Gemini, Groq, OpenRouter to local models via Ollama. It features intelligent routing based on context length and custom rules, plus full streaming support.

## Why add CCProxy?

- **Universal Compatibility**: Allows Claude Code users to break free from vendor lock-in and use any AI model
- **Local Model Support**: Enables running local models with Claude Code via Ollama integration  
- **Active Development**: Regular updates and strong community support
- **MIT Licensed**: Open source and free to use

## Changes

This PR adds only one line to README.md in the Tooling section, following the existing format.

Thank you for maintaining this awesome list!