### PR TITLE
Fix: Protect-labels workflow incorrectly flagging template labels

### DIFF
--- a/.github/workflows/protect-labels.yml
+++ b/.github/workflows/protect-labels.yml
@@ -39,8 +39,10 @@ jobs:
               return;
             }
             
-            // Allow adding template labels (resource-submission and pending-validation)
-            // These are added automatically by GitHub when issues are created from templates
+            // WORKAROUND: Allow adding template labels (resource-submission and pending-validation)
+            // GitHub attributes labels from issue templates as being added by the issue author,
+            // not by GitHub itself. Without this exception, the protect-labels workflow would
+            // incorrectly flag and revert these template-defined labels as unauthorized changes.
             if (action === 'labeled' && (label === 'resource-submission' || label === 'pending-validation')) {
               console.log(`Allowing template label "${label}" to be added (used by issue templates)`);
               return;

--- a/.github/workflows/protect-labels.yml
+++ b/.github/workflows/protect-labels.yml
@@ -39,6 +39,13 @@ jobs:
               return;
             }
             
+            // Allow adding template labels (resource-submission and pending-validation)
+            // These are added automatically by GitHub when issues are created from templates
+            if (action === 'labeled' && (label === 'resource-submission' || label === 'pending-validation')) {
+              console.log(`Allowing template label "${label}" to be added (used by issue templates)`);
+              return;
+            }
+            
             // Check if actor has write permissions
             const actorPermission = context.payload.sender.author_association;
             const isRepoOwner = context.repo.owner === actor;


### PR DESCRIPTION
## Summary
- Fixed protect-labels workflow that was incorrectly removing labels added by GitHub issue templates
- Added workaround to allow `resource-submission` and `pending-validation` labels to be added without triggering protection

## Problem
When users submit new resources using the issue template, GitHub automatically adds the `resource-submission` and `pending-validation` labels. However, these labels appear to be added by the issue author (not by GitHub), causing the protect-labels workflow to:
1. Flag them as unauthorized changes
2. Remove the labels
3. Post warning comments to users
4. Break the validation workflow that depends on these labels

## Solution
Added a simple workaround that allows these specific template labels to be added without restriction:
- Still protects these labels from unauthorized removal
- Minimal risk since validation workflow handles any misuse gracefully
- Clean and focused fix that addresses the root cause

## Test Plan
- [ ] Create a new issue using the resource submission template
- [ ] Verify that `resource-submission` and `pending-validation` labels are retained
- [ ] Verify no "unauthorized label change" warnings appear
- [ ] Verify validation workflow runs successfully
- [ ] Test that other protected labels still trigger protection as expected

🤖 Generated with [Claude Code](https://claude.ai/code)