### PR TITLE
Add CC Chat - Chinese Community Platform for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,13 +447,24 @@ A humble but handy utility for viewing Claude Code `.jsonl` conversation files i
 </details>
 <br>
 
-[`Claude Code Templates`](https://github.com/davila7/claude-code-templates) &nbsp; by &nbsp; [Daniel Avila](https://github.com/davila7)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
+[`Claude Code Templates`](https://github.com/davila7/claude-code-templates) &nbsp; by &nbsp; [Daniel Avila](https://github.com/davila7)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
 Incredibly awesome collection of resources from every category in this list, presented with a neatly polished UI, great features like usage dashboard, analytics, and everything from slash commands to hooks to agents. An awesome companion for this awesome list.
 
 <details>
 <summary>📊 GitHub Stats</summary>
 
 ![GitHub Stats for claude-code-templates](https://github-readme-stats-plus-theta.vercel.app/api/pin/?repo=claude-code-templates&username=davila7&all_stats=true&stats_only=true)
+
+</details>
+<br>
+
+[`CC Chat`](https://github.com/Optima-Chat/cc-chat) &nbsp; by &nbsp; [Optima Chat](https://github.com/Optima-Chat)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
+Chinese community platform for Claude Code users. Features natural language CLI integration (just talk to Claude to post), Reddit content auto-sync with translation, full community features (voting, comments, bookmarks, notifications), and Web + CLI dual interface. 20+ commands with user-friendly prompts.
+
+<details>
+<summary>📊 GitHub Stats</summary>
+
+![GitHub Stats for cc-chat](https://github-readme-stats-plus-theta.vercel.app/api/pin/?repo=cc-chat&username=Optima-Chat&all_stats=true&stats_only=true)
 
 </details>
 <br>


### PR DESCRIPTION
## Description
This PR adds CC Chat to the Tooling section - a comprehensive Chinese community platform for Claude Code users.

## What is CC Chat?
CC Chat is a full-featured community platform designed specifically for Claude Code users in China, featuring:

- **Natural Language CLI**: Just talk to Claude to post (e.g., "帮我发个帖子分享我的 MCP 配置")
- **Web + CLI Dual Interface**: Use via browser at [cc-chat.dev](https://www.cc-chat.dev) or 20+ CLI commands
- **Auto Content Sync**: Automatically scrapes and translates quality Claude Code content from Reddit
- **Full Community Features**: Voting, nested comments, bookmarks, notifications, user profiles
- **Smart Tagging**: MCP, 技巧, 项目, 问题 and more
- **GitHub OAuth**: Easy login integration

## Tech Stack
- TypeScript + Commander.js (CLI)
- Next.js 15 + React 19 (Web)
- Fastify + PostgreSQL + Redis (API)
- Railway (API) + Vercel (Web) deployment

## Links
- Website: https://www.cc-chat.dev
- GitHub: https://github.com/Optima-Chat/cc-chat
- npm: https://www.npmjs.com/package/@optima-chat/cc-chat

## Category
Added to **Tooling 🧰 > General** section, positioned alphabetically between "Claude Code Templates" and "Claude Composer".

Thank you for maintaining this awesome list!