### PR TITLE
Add DevRag - Free local RAG for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,18 @@ A systematic development framework that transforms Claude Code into a proactive 
 </details>
 <br>
 
-[`Rulesync`](https://github.com/dyoshikawa/rulesync) &nbsp; by &nbsp; [dyoshikawa](https://github.com/dyoshikawa)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
+[`DevRag`](https://github.com/tomohiro-owada/devrag) &nbsp; by &nbsp; [towada](https://github.com/tomohiro-owada)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
+Free local RAG for Claude Code. Save tokens & time with vector search - indexes markdown docs and finds relevant info without reading entire files (40x fewer tokens, 15x faster).
+
+<details>
+<summary>📊 GitHub Stats</summary>
+
+![GitHub Stats for devrag](https://github-readme-stats-plus-theta.vercel.app/api/pin/?repo=devrag&username=tomohiro-owada&all_stats=true&stats_only=true)
+
+</details>
+<br>
+
+[`Rulesync`](https://github.com/dyoshikawa/rulesync) &nbsp; by &nbsp; [dyoshikawa](https://github.com/dyoshikawa)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
 A Node.js CLI tool that automatically generates configs (rules, ignore files, MCP servers, commands, and subagents) for various AI coding agents. Rulesync can convert configs between Claude Code and other AI agents in both directions.
 
 <details>


### PR DESCRIPTION
## Description

Adds [DevRag](https://github.com/tomohiro-owada/devrag) to the Tooling → General section.

DevRag is a free local RAG (Retrieval-Augmented Generation) system designed specifically for Claude Code users. It helps save tokens and time by using vector search instead of reading entire documents.

## Key Features
- 🚀 **40x fewer tokens**: Vector search retrieves only relevant chunks (~200 tokens vs ~12,000)
- ⚡ **15x faster**: Search in 100ms vs 30 seconds of reading
- 🆓 **Completely free**: Runs locally, no API required
- 🔍 **Auto-discovery**: Claude Code finds documents without knowing file names
- 🖥️ **Cross-platform**: macOS / Linux / Windows
- 🌐 **Multilingual**: Supports 100+ languages including Japanese & English

## Category
Added to **Tooling → General** (alphabetically placed between ContextKit and Rulesync)

## License
MIT