### PR TITLE
Add claude-starter: Production-ready configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,13 +279,24 @@ A mirror of the Anthropic&copy; PBC documentation site for Claude/Code, but with
 </details>
 <br>
 
-[`ClaudoPro Directory`](https://github.com/JSONbored/claudepro-directory) &nbsp; by &nbsp; [ghost](https://github.com/JSONbored)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT  
+[`ClaudoPro Directory`](https://github.com/JSONbored/claudepro-directory) &nbsp; by &nbsp; [ghost](https://github.com/JSONbored)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
 Well-crafted, wide selection of Claude Code hooks, slash commands, subagent files, and more, covering a range of specialized tasks and workflows. Better resources than your average "Claude-template-for-everything" site.
 
 <details>
 <summary>📊 GitHub Stats</summary>
 
 ![GitHub Stats for claudepro-directory](https://github-readme-stats-plus-theta.vercel.app/api/pin/?repo=claudepro-directory&username=JSONbored&all_stats=true&stats_only=true)
+
+</details>
+<br>
+
+[`claude-starter`](https://github.com/raintree-technology/claude-starter) &nbsp; by &nbsp; [zacharyr0th](https://github.com/zacharyr0th)  &nbsp;&nbsp;⚖️&nbsp;&nbsp;MIT
+Production-ready Claude Code configuration template with 40 auto-activating skills across 8 domains (AI, Payments, Banking, Blockchain, Backend, Mobile, Data), TOON format support for 30-60% token savings, 7 slash commands, and native Zig encoder/decoder. Drop-in `.claude/` directory with comprehensive documentation.
+
+<details>
+<summary>📊 GitHub Stats</summary>
+
+![GitHub Stats for claude-starter](https://github-readme-stats-plus-theta.vercel.app/api/pin/?repo=claude-starter&username=raintree-technology&all_stats=true&stats_only=true)
 
 </details>
 <br>


### PR DESCRIPTION
## Description

This PR adds **[claude-starter](https://github.com/raintree-technology/claude-starter)** to the **Workflows & Knowledge Guides** section.

## What is claude-starter?

A production-ready Claude Code configuration template that provides a comprehensive `.claude/` directory with:

- **40 auto-activating skills** organized across 8 logical domains
- **TOON format support** for 30-60% token savings on tabular data
- **7 slash commands** for format conversion, token analysis, and skill marketplace integration
- **Native Zig encoder/decoder** (20x faster than JavaScript implementations)
- **Complete documentation** with examples and customization guides

## Features

**Skill Domains:**
1. **AI & Claude Code** (7 skills) - Anthropic API, Claude Code CLI, builders for commands/hooks/skills/MCP, settings expert
2. **Payments & Commerce** (3 skills) - Stripe (3,253 docs), Whop (212 docs), Shopify (25 docs)
3. **Banking** (5 skills) - Plaid base + Auth, Transactions, Identity, Accounts (659 docs)
4. **Blockchain** (18 skills) - Aptos (150 docs) + 8 sub-skills, Shelby Protocol (52 docs) + 7 sub-skills, Decibel (44 docs)
5. **Backend** (1 skill) - Supabase (2,616 docs) - PostgreSQL, auth, realtime, storage, edge functions
6. **Mobile** (5 skills) - Expo (810 docs) + 3 sub-skills (EAS Build, Update, Router), iOS (4 docs)
7. **Data** (1 skill) - TOON formatter with auto-detection and optimization

**TOON Format Utilities:**
- 30-60% token savings on arrays with 5+ items and 60%+ field uniformity
- Native Zig implementation (357KB binary)
- 5 slash commands: `/convert-to-toon`, `/toon-encode`, `/toon-decode`, `/toon-validate`, `/analyze-tokens`
- Complete specification with 13 passing tests

**Skills Marketplace Integration:**
- Browse 13,000+ community skills via SkillsMP
- 2 slash commands: `/discover-skills`, `/install-skill`
- Personal and project-level installation

## Installation Options

**Full template:**
```bash
cp -r claude-starter/.claude /your-project/.claude
```

**Selective (specific domains):**
```bash
cp -r claude-starter/.claude/skills/{stripe,supabase} /your-project/.claude/skills/
```

**Just TOON tools:**
```bash
cp -r claude-starter/.claude/utils/toon /your-project/.claude/utils/
cp -r claude-starter/.claude/commands/toon* /your-project/.claude/commands/
```

## Documentation

Skills work immediately with built-in knowledge. Optional comprehensive API documentation can be pulled separately:

```bash
pipx install docpull
docpull https://docs.stripe.com -o .claude/skills/stripe/docs  # 3,253 files
docpull https://supabase.com/docs -o .claude/skills/supabase/docs  # 2,616 files
```

## Why Workflows & Knowledge Guides?

claude-starter is a comprehensive configuration template that provides tightly coupled Claude Code resources across multiple domains. It fits the definition of a workflow by facilitating specific development patterns and providing systematic knowledge organization.

## Links

- **Repository:** https://github.com/raintree-technology/claude-starter
- **Complete Reference:** See `.claude/DIRECTORY.md`
- **Quick Start:** See `.claude/README.md`
- **TOON Format:** Native Zig implementation with comprehensive utilities

## Checklist

- [x] Added to appropriate section (Workflows & Knowledge Guides)
- [x] Follows established formatting pattern (author attribution, license, stats card)
- [x] Includes concise, accurate description highlighting key features
- [x] Repository is public and accessible
- [x] Documentation is comprehensive
- [x] MIT License
- [x] Skills follow Claude Code best practices