### PR TITLE
Add AgentFund to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 
 ### General
 
+- [AgentFund](https://github.com/RioBot-Grind/agentfund-skill) by [RioBot-Grind](https://github.com/RioBot-Grind) - Crowdfunding for AI agents on Base chain. Create fundraising proposals with milestones, track funded projects, and receive payments via escrow. MCP server also available.
 - [AI Agent, AI Spy](https://youtu.be/0ANECpNdt-4) by [Whittaker & Tiwari](https://signalfoundation.org/) - Members from the Signal Foundation with some really great tips and tricks on how to turn your operating system into an instrument of total surveillance, and why some companies are doing this really awesome thing. [warning: YouTube link].
 - [cc-devops-skills](https://github.com/akin-ozer/cc-devops-skills) by [akin-ozer](https://github.com/akin-ozer) - Immensely detailed set of skills for DevOps Engineers (or anyone who has to deploy code, really). Works with validations, generators, shell scripts and CLI tools to create high quality IaC code for about any platform you've ever struggled painfully to work with. Worth downloading even just as a source of documentation.
 - [Claude Codex Settings](https://github.com/fcakyon/claude-codex-settings) by [fatih akyon](https://github.com/fcakyon) - A well-organized, well-written set of plugins covering core developer activities, such as working with common cloud platforms like GitHub, Azure, MongoDB, and popular services such as Tavily, Playwright, and more. Clear, not overly-opinionated, and compatible with a few other providers.


### PR DESCRIPTION
## AgentFund

Crowdfunding for AI agents on Base chain - the first infrastructure for agents to fundraise autonomously.

**Features:**
- Create fundraising proposals with milestone amounts
- Track project status and funding
- Request milestone payments via escrow contracts

**Links:**
- Skill: https://github.com/RioBot-Grind/agentfund-skill  
- MCP Server: https://github.com/RioBot-Grind/agentfund-mcp