### PR TITLE
Add agnix - AI agent config linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 
 ### General
 
+- [agnix](https://github.com/avifenesh/agnix) by [Avi Fenesh](https://github.com/avifenesh) - Linter for AI agent configurations (CLAUDE.md, skills, hooks, agents, plugins, MCP) with 156 validation rules, auto-fix, LSP server, and IDE extensions for VS Code, JetBrains, Neovim, and Zed.
 - [cc-sessions](https://github.com/GWUDCAP/cc-sessions) by [toastdev](https://github.com/satoastshi) - An opinionated approach to productive development with Claude Code.
 - [cc-tools](https://github.com/Veraticus/cc-tools) by [Josh Symonds](https://github.com/Veraticus) - High-performance Go implementation of Claude Code hooks and utilities. Provides smart linting, testing, and statusline generation with minimal overhead.
 - [ccexp](https://github.com/nyatinte/ccexp) by [nyatinte](https://github.com/nyatinte) - Interactive CLI tool for discovering and managing Claude Code configuration files and slash commands with a beautiful terminal UI.


### PR DESCRIPTION
Adds [agnix](https://github.com/avifenesh/agnix) to the Tooling > General section.

**What it is**: A linter for AI agent configurations -- validates CLAUDE.md, skills, hooks, agents, plugins, and MCP configs with 156 rules and auto-fix.

**Why it belongs here**: agnix validates the entire Claude Code configuration surface area (skills, hooks, agents, plugins, memory files). It includes an LSP server for real-time editor diagnostics and IDE extensions for VS Code, JetBrains, Neovim, and Zed.

- Published on [npm](https://www.npmjs.com/package/agnix), [crates.io](https://crates.io/crates/agnix-cli), and Homebrew
- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix) on the marketplace
- GitHub Action available (`avifenesh/agnix@v0`)
- MIT/Apache-2.0 licensed