### PR TITLE
Add oh-my-claude statusline framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 - [claude-code-statusline](https://github.com/rz1989s/claude-code-statusline) by [rz1989s](https://github.com/rz1989s) - Enhanced 4-line statusline for Claude Code with themes, cost tracking, and MCP server monitoring.
 - [claude-powerline](https://github.com/Owloops/claude-powerline) by [Owloops](https://github.com/Owloops) - A vim-style powerline statusline for Claude Code with real-time usage tracking, git integration, custom themes, and more.
 - [claudia-statusline](https://github.com/hagan/claudia-statusline) by [Hagan Franks](https://github.com/hagan) - High-performance Rust-based statusline for Claude Code with persistent stats tracking, progress bars, and optional cloud sync. Features SQLite-first persistence, git integration, context progress bars, burn rate calculation, XDG-compliant with theme support (dark/light, NO_COLOR).
+- [oh-my-claude](https://github.com/npow/oh-my-claude) by [npow](https://github.com/npow) - Like oh-my-zsh but for Claude Code. An extensible statusline framework with themes (tamagotchi, boss-battle, RPG, narrator, and more), dozens of mix-and-match segments, and a plugin system for custom segments. Zero npm dependencies.
 
 <br>
 


### PR DESCRIPTION
Adds [oh-my-claude](https://github.com/npow/oh-my-claude) to the General statusline section.

**oh-my-claude** is like oh-my-zsh but for Claude Code — an extensible statusline framework with themes, dozens of mix-and-match segments, and a plugin system for custom segments. Zero npm dependencies.

### Themes

**tamagotchi** — virtual pet, growing garden, draining coffee
![tamagotchi](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/tamagotchi.png)

**boss-battle** — dungeon crawl with weather and battle music
![boss-battle](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/boss-battle.png)

**rpg** — D&D character sheet, speedrun timer, cat companion
![rpg](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/rpg-developer.png)

**danger-zone** — 3 hours in, $18 spent, everything on fire
![danger-zone](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/danger-zone.png)

**narrator** — third-person text adventure with vibes
![narrator](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/narrator.png)

**coworker** — fake Slack messages and fortune cookie wisdom
![coworker](https://raw.githubusercontent.com/npow/oh-my-claude/main/screenshots/coworker.png)