### PR TITLE
Add ClaudeUsageBar — macOS menu bar Claude.ai usage tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 - [Claude Code Usage Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) by [Maciek-roboblog](https://github.com/Maciek-roboblog) - A real-time terminal-based tool for monitoring Claude Code token usage. It shows live token consumption, burn rate, and predictions for token depletion. Features include visual progress bars, session-aware analytics, and support for multiple subscription plans.
 - [Claudex](https://github.com/kunwar-shah/claudex) by [Kunwar Shah](https://github.com/kunwar-shah) - Claudex - A web-based browser for exploring your Claude Code conversation history across projects. Indexes your codebase for full-text search. Nice, easy-to-navigate UI. Simple dashboard interface for high-level analytics, and multiple export options as well. (And completely local w/ no telemetry!).
 - [viberank](https://github.com/sculptdotfun/viberank) by [nikshepsvn](https://github.com/nikshepsvn) - A community-driven leaderboard tool that enables developers to visualize, track, and compete based on their Claude Code usage statistics. It features robust data analytics, GitHub OAuth, data validation, and user-friendly CLI/web submission methods.
+- [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) by [yagcioglutoprak](https://github.com/yagcioglutoprak) - macOS menu bar app that shows your Claude.ai session (5-hour) and weekly usage limits in real-time. Color-coded green/yellow/red, macOS notifications at 80%/95%, zero setup (reads local browser cookies from Chrome/Arc/Firefox/Safari/Brave/Edge), no Electron, one-command install.
 
 ### Orchestrators
 
@@ -383,3 +384,4 @@ This list is licensed under [Creative Commons CC BY-NC-ND 4.0](https://creativec
 
 
 <!-- OBLIGATORY GUARD AGAINST SILLY END-OF-FILE PROBLEM -->
+


### PR DESCRIPTION
Adds [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) to the Usage Monitors section.

A macOS menu bar app that shows Claude.ai session (5-hour) and weekly usage limits in real-time. Complements the existing CLI-based usage monitors by providing always-visible menu bar visibility for the claude.ai web app limits.

**Key details:**
- Color-coded indicator: green/yellow/red
- macOS notifications at 80% and 95%
- Zero setup — reads local browser cookies (Chrome, Arc, Firefox, Safari, Brave, Edge)
- No Electron, ~900 lines Python
- One-command install: `curl -fsSL https://raw.githubusercontent.com/yagcioglutoprak/ClaudeUsageBar/main/install.sh | bash`
- MIT licensed