### PR TITLE
Add amux — parallel Claude Code agent multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 
 ## Latest Additions
 
+- **[amux](https://github.com/mixpeek/amux)** — Open-source Claude Code agent multiplexer: parallel sessions via tmux, self-healing watchdog, kanban board, and mobile PWA dashboard.
+
 - [Dippy](https://github.com/ldayton/Dippy) by [Lily Dayton](https://github.com/ldayton) - Auto-approve safe bash commands using AST-based parsing, while prompting for destructive operations. Solves permission fatigue without disabling safety. Supports Claude Code, Gemini CLI, and Cursor.
 - [sudocode](https://github.com/sudocode-ai/sudocode) by [ssh-randy](https://github.com/ssh-randy) - Lightweight agent orchestration dev tool that lives in your repo. Integrates with various specification frameworks. It's giving Jira.
 - [claude-tmux](https://github.com/nielsgroen/claude-tmux) by [Niels Groeneveld](https://github.com/nielsgroen) - Manage Claude Code within tmux. A tmux popup of all your Claude Code instances, enabling quick switching, status monitoring, session lifecycle management, with git worktree and pull request support.
@@ -191,6 +193,7 @@ Claude Code is a CLI-based coding assistant from [Anthropic](https://www.anthrop
 
 ### Orchestrators
 
+- [amux](https://github.com/mixpeek/amux) by [Mixpeek](https://github.com/mixpeek) - Open-source Claude Code agent multiplexer that runs dozens of parallel Claude Code sessions unattended via tmux. Features a mobile PWA dashboard, atomic kanban board (SQLite), self-healing watchdog, agent-to-agent REST API (POST /send), iCal sync, and conversation forking. Single Python file, MIT licensed.
 - [Auto-Claude](https://github.com/AndyMik90/Auto-Claude) by [AndyMik90](https://github.com/AndyMik90) - Autonomous multi-agent coding framework for Claude Code (Claude Agent SDK) that integrates the full SDLC - "plans, builds, and validates software for you". Features a slick kanban-style UI and a well-designed but not over-engineered agent orchestration system.
 - [Claude Code Flow](https://github.com/ruvnet/claude-code-flow) by [ruvnet](https://github.com/ruvnet) - This mode serves as a code-first orchestration layer, enabling Claude to write, edit, test, and optimize code autonomously across recursive agent cycles.
 - [Claude Squad](https://github.com/smtg-ai/claude-squad) by [smtg-ai](https://github.com/smtg-ai) - Claude Squad is a terminal app that manages multiple Claude Code, Codex (and other local agents including Aider) in separate workspaces, allowing you to work on multiple tasks simultaneously.


### PR DESCRIPTION
## Resource to add

**amux** — Open-source Claude Code agent multiplexer

- **GitHub**: https://github.com/mixpeek/amux
- **Homepage**: https://amux.io
- **Category**: Tooling → Orchestrators

## Description

amux runs dozens of Claude Code sessions in parallel, unattended, via tmux. It includes:

- **Self-healing watchdog** — auto-restarts stalled sessions
- **Atomic kanban board** (SQLite CAS) — agents claim tasks without conflicts
- **Agent-to-agent REST API** — POST /api/sessions/NAME/send for orchestration
- **Mobile PWA dashboard** — manage all agents from your phone
- **iCal sync** — board items with due dates push to Google/Apple Calendar
- **Single Python file** — zero config, just `python3 amux-server.py`
- MIT licensed, no cloud dependency

## Checklist

- [x] Resource is free to use or clearly labeled as paid
- [x] Links are working and point to the correct resource
- [x] Description is accurate and concise
- [x] Added to the correct category (Orchestrators)
