### PR TITLE
Add claude-code-workflow — AGENTS.md template and workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [sudocode](https://github.com/sudocode-ai/sudocode) by [ssh-randy](https://github.com/ssh-randy) - Lightweight agent orchestration dev tool that lives in your repo. Integrates with various specification frameworks. It's giving Jira.
 - [claude-tmux](https://github.com/nielsgroen/claude-tmux) by [Niels Groeneveld](https://github.com/nielsgroen) - Manage Claude Code within tmux. A tmux popup of all your Claude Code instances, enabling quick switching, status monitoring, session lifecycle management, with git worktree and pull request support.
 - [claude-esp](https://github.com/phiat/claude-esp) by [phiat](https://github.com/phiat) - Go-based TUI that streams Claude Code's hidden output (thinking, tool calls, subagents) to a separate terminal. Watch multiple sessions simultaneously, filter by content type, and track background tasks. Ideal for debugging or understanding what Claude is doing under the hood without interrupting your main session.
+- [claude-code-workflow](https://github.com/shellsage-ai/claude-code-workflow) by [ShellSage AI](https://github.com/shellsage-ai) - AGENTS.md starter template and workflow guide for structuring AI-assisted development. Define project conventions once, get consistent Claude Code results every session.
 
 
 ## Contents


### PR DESCRIPTION
## What is this?

[claude-code-workflow](https://github.com/shellsage-ai/claude-code-workflow) — A starter AGENTS.md template and workflow guide for Claude Code projects.

### What it provides
- Ready-to-use AGENTS.md template with sections for tech stack, conventions, commands, and boundaries
- Workflow tips for session management and team projects
- MIT licensed, free to use

**Category:** Tooling (alphabetically placed after claude-esp)