### PR TITLE
Add Accessibility Multiskill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 
 ### General
 
+- [Accessibility Multiskill](https://github.com/lukeslp/accessibility-multiskill) by [Luke Steuber](https://github.com/lukeslp) - WCAG 2.2 AA accessibility skill for Claude Code covering motor, cognitive, visual, and communication disabilities. Includes 10 audit scripts and production CSS utilities.
 - [AgentSys](https://github.com/avifenesh/agentsys) by [avifenesh](https://github.com/avifenesh) - Workflow automation system for Claude with a group of useful plugins, agents, and skills. Automates task-to-production workflows, PR management, code cleanup, performance investigation, drift detection, and multi-agent code review. Includes [agnix](https://github.com/avifenesh/agnix) for linting agent configurations. Built on thousands of lines of code with thousands of tests. Uses deterministic detection (regex, AST) with LLM judgment for efficiency. Used on many production systems.
 - [AI Agent, AI Spy](https://youtu.be/0ANECpNdt-4) by [Whittaker & Tiwari](https://signalfoundation.org/) - Members from the Signal Foundation with some really great tips and tricks on how to turn your operating system into an instrument of total surveillance, and why some companies are doing this really awesome thing. [warning: YouTube link].
 - [Book Factory](https://github.com/robertguss/claude-skills) by [Robert Guss](https://github.com/robertguss) - A comprehensive pipeline of Skills that replicates traditional publishing infrastructure for nonfiction book creation using specialized Claude skills.


### PR DESCRIPTION
## Summary

Adds [Accessibility Multiskill](https://github.com/lukeslp/accessibility-multiskill) to the Agent Skills → General section.

WCAG 2.2 AA accessibility skill for Claude Code covering motor, cognitive, visual, and communication disabilities — switch access, eye gaze, keyboard-only navigation, dyslexia-friendly typography, forced colors mode, and more. Includes 10 stdlib-only Python audit scripts and production CSS utilities.

## Checklist

- [x] Alphabetically ordered (before AgentSys — "Ac" < "Ag")
- [x] Follows existing format
- [x] Links valid
- [x] Single addition only