### PR TITLE
Add auto-co: autonomous AI company framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 ### Orchestrators
 
 - [Auto-Claude](https://github.com/AndyMik90/Auto-Claude) by [AndyMik90](https://github.com/AndyMik90) - Autonomous multi-agent coding framework for Claude Code (Claude Agent SDK) that integrates the full SDLC - "plans, builds, and validates software for you". Features a slick kanban-style UI and a well-designed but not over-engineered agent orchestration system.
+- [auto-co](https://github.com/NikitaDmitrieff/auto-co-meta) by [Nikita Dmitrieff](https://github.com/NikitaDmitrieff) - Fully autonomous AI company framework that runs a 14-agent team (CEO, CTO, CFO, marketing, etc.) in a continuous loop using Claude Code CLI. Ships with a live dashboard, npm CLI (`create-auto-co`), and 120+ completed autonomous cycles. Open-source core with hosted tier.
 - [Claude Code Flow](https://github.com/ruvnet/claude-code-flow) by [ruvnet](https://github.com/ruvnet) - This mode serves as a code-first orchestration layer, enabling Claude to write, edit, test, and optimize code autonomously across recursive agent cycles.
 - [Claude Squad](https://github.com/smtg-ai/claude-squad) by [smtg-ai](https://github.com/smtg-ai) - Claude Squad is a terminal app that manages multiple Claude Code, Codex (and other local agents including Aider) in separate workspaces, allowing you to work on multiple tasks simultaneously.
 - [Claude Swarm](https://github.com/parruda/claude-swarm) by [parruda](https://github.com/parruda) - Launch Claude Code session that is connected to a swarm of Claude Code Agents.


### PR DESCRIPTION
## Summary

- Adds [auto-co](https://github.com/NikitaDmitrieff/auto-co-meta) to the **Orchestrators** section
- auto-co is a fully autonomous AI company framework running 14 specialized agents (CEO, CTO, CFO, marketing, etc.) in a continuous loop via Claude Code CLI
- Ships with live dashboard, npm CLI (`create-auto-co`), and 120+ completed autonomous cycles
- Open-source (MIT) with hosted paid tier

## Links

- GitHub: https://github.com/NikitaDmitrieff/auto-co-meta
- npm: https://www.npmjs.com/package/create-auto-co
- Landing: https://runautoco.com
- Live dashboard: https://app.runautoco.com