### PR TITLE
Add BurnRate - AI coding cost analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@
 
 ### Usage Monitors
 
+- [BurnRate](https://github.com/burnrate-dev/burnrate) by [burnrate-dev](https://github.com/burnrate-dev) - Multi-provider AI coding cost analytics CLI. Tracks token usage, costs, and optimization opportunities across 7 providers (Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, Codex). Features a local dashboard, 46 optimization rules, rate limit monitoring, team budgets, and PDF report generation. Written in Go, single binary.
 - [CC Usage](https://github.com/ryoppippi/ccusage) by [ryoppippi](https://github.com/ryoppippi) - Handy CLI tool for managing and analyzing Claude Code usage, based on analyzing local Claude Code logs. Presents a nice dashboard regarding cost information, token consumption, etc.
 - [ccflare](https://github.com/snipeship/ccflare) by [snipeship](https://github.com/snipeship) - Claude Code usage dashboard with a web-UI that would put Tableau to shame. Thoroughly comprehensive metrics, frictionless setup, detailed logging, really really nice UI.
 - [ccflare -> **better-ccflare**](https://github.com/tombii/better-ccflare/) by [tombii](https://github.com/tombii) - A well-maintained and feature-enhanced fork of the glorious `ccflare` usage dashboard by @snipeship (which at the time of writing has not had an update in a few months). `better-ccflare` builds on this foundation with some performance enhancements, extended provider support, bug fixes, Docker deployment, and more.


### PR DESCRIPTION
## What is BurnRate?

[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

**Key features:**
- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring
- Team budgets and alerts
- PDF report generation
- Written in Go, single binary, no dependencies

GitHub: https://github.com/burnrate-dev/burnrate

Added to the **Usage Monitors** section under **Tooling**, which is the most appropriate category for a multi-provider cost analytics tool.