### PR TITLE
Add Xquik X Twitter Scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 
 <br>
 
+- [Xquik X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) by [Xquik-dev](https://github.com/Xquik-dev) - X/Twitter data platform skill with 76 REST API endpoints covering tweet search, user lookup, follower extraction, 20 bulk extraction tools, account monitoring, giveaway draws, trending topics, write actions (tweet, like, retweet, follow, DM), Telegram integrations, and MCP server (v2 sandbox + v1 legacy). Works with Claude Code, Cursor, Codex, Copilot, Gemini CLI, and 40+ agents via the skills.sh protocol.
 ## Workflows & Knowledge Guides 🧠
 
 > A workflow is a tightly coupled set of Claude Code-native resources that facilitate specific projects


### PR DESCRIPTION
Adds [Xquik X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) to the Agent Skills section.

An AI agent skill that gives coding agents deep knowledge of the Xquik X/Twitter data platform:
- 76 REST API endpoints across 12 resource groups
- 20 bulk extraction tools (replies, retweets, followers, communities, Spaces, etc.)
- Account monitoring with HMAC-signed webhooks
- MCP server (v2: 2-tool sandbox, v1: 18 discrete tools)
- Giveaway draws, trending topics, write actions, Telegram integrations
- Install: `npx skills add Xquik-dev/x-twitter-scraper`
- MIT licensed

Supports Claude Code, Cursor, Codex, Copilot, Gemini CLI, Windsurf, and 40+ agents.

Disclosure: I am the developer of Xquik.