### PR TITLE
Add claude-tts-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@
 - [tweakcc](https://github.com/Piebald-AI/tweakcc) by [Piebald-AI](https://github.com/Piebald-AI) - Command-line tool to customize your Claude Code styling.
 - [Vibe-Log](https://github.com/vibe-log/vibe-log-cli) by [Vibe-Log](https://github.com/vibe-log) - Analyzes your Claude Code prompts locally (using CC), provides intelligent session analysis and actionable strategic guidance - works in the statusline and produces very pretty HTML reports as well. Easy to install and remove.
 - [viwo-cli](https://github.com/OverseedAI/viwo) by [Hal Shin](https://github.com/hal-shin) - Run Claude Code in a Docker container with git worktrees as volume mounts to enable safer usage of `--dangerously-skip-permissions` for frictionless one-shotting prompts. Allows users to spin up multiple instances of Claude Code in the background easily with reduced permission fatigue.
+- [claude-tts-mcp](https://github.com/mitchthestonky/claude-tts-mcp) by [Mitch Hazelhurst](https://github.com/mitchthestonky) - Free, local text-to-speech MCP server for Claude Code using Kokoro. No API keys, runs entirely offline via npm.
 - [VoiceMode MCP](https://github.com/mbailey/voicemode) by [Mike Bailey](https://github.com/mbailey) - VoiceMode MCP brings natural conversations to Claude Code. It supports any OpenAI API compatible voice services and installs free and open source voice services (Whisper.cpp and Kokoro-FastAPI).
 
 ### IDE Integrations


### PR DESCRIPTION
Closes #488.

Adds [claude-tts-mcp](https://github.com/mitchthestonky/claude-tts-mcp) to the Tooling > General section.

Free, local TTS MCP server for Claude Code using Kokoro. No API keys, runs entirely offline via npm.